### PR TITLE
Add new bfastpp parameter sbins for number of seasonal dummy bins

### DIFF
--- a/R/bfast01.R
+++ b/R/bfast01.R
@@ -8,7 +8,7 @@
 #' steps:
 #' 
 #' 1. The data is preprocessed with bfastpp using the arguments
-#' order/lag/slag/na.action/stl.
+#' order/lag/slag/na.action/stl/sbins.
 #' 
 #' 2. A linear model with the given formula is fitted. By default a suitable
 #' formula is guessed based on the preprocessing parameters.
@@ -70,6 +70,7 @@
 #' omitted.
 #' @param na.action arguments passed on to \code{\link[bfast]{bfastpp}}
 #' @param stl argument passed on to \code{\link[bfast]{bfastpp}}
+#' @param sbins argument passed on to \code{\link[bfast]{bfastpp}}
 #' @return \code{bfast01} returns a list of class \code{"bfast01"} with the
 #' following elements: \item{call}{the original function call.} \item{data}{the
 #' data preprocessed by \code{"bfastpp"}.} \item{formula}{the model formulae.}
@@ -132,7 +133,7 @@ bfast01 <- function(data, formula = NULL,
                     test = "OLS-MOSUM", level = 0.05, aggregate = all,
                     trim = NULL, bandwidth = 0.15, functional = "max",
                     order = 3, lag = NULL, slag = NULL, na.action = na.omit, 
-                    reg = "lm", stl = "none")
+                    reg = "lm", stl = "none", sbins = 1)
 {
   # Error catching
   if(!(reg %in% c("lm","rlm"))) stop("Regression method unknown. ?bfast01")
@@ -141,7 +142,7 @@ bfast01 <- function(data, formula = NULL,
   stl <- match.arg(stl, c("none", "trend", "seasonal", "both"))
   if (!inherits(data, "data.frame")) 
     data <- bfastpp(data, order = order, lag = lag, slag = slag, 
-                    na.action = na.action, stl = stl)
+                    na.action = na.action, stl = stl, sbins = sbins)
   if (is.null(formula)) {
     formula <- c(trend = !(stl %in% c("trend", "both")), 
                  harmon = order > 0 & !(stl %in% c("seasonal", "both")), 

--- a/R/bfastmonitor.R
+++ b/R/bfastmonitor.R
@@ -80,6 +80,8 @@
 #' @param verbose logical. Should information about the monitoring be printed
 #' during computation?
 #' @param plot logical. Should the result be plotted?
+#' @param sbins numeric. Number of seasonal dummies, passed to
+#' \code{\link{bfastpp}}.
 #' @return \code{bfastmonitor} returns an object of class
 #' \code{"bfastmonitor"}, i.e., a list with components as follows.
 #' \item{data}{original \code{"ts"} time series,} \item{tspp}{preprocessed
@@ -194,16 +196,16 @@ bfastmonitor <- function(data, start,
                          order = 3, lag = NULL, slag = NULL,
                          history = c("ROC", "BP", "all"),
                          type = "OLS-MOSUM", h = 0.25, end = 10, level = 0.05,
-                         hpc = "none", verbose = FALSE, plot = FALSE)
+                         hpc = "none", verbose = FALSE, plot = FALSE, sbins = 1)
 {
   
   if (getOption("bfast.prefer_matrix_methods", FALSE)) {
     return(.bfastmonitor.matrix(data,start,formula,order, lag, slag,
-                                 history, type, h, end, level, hpc, verbose, plot))
+        history, type, h, end, level, hpc, verbose, plot, sbins))
   }
   else {
     return(.bfastmonitor.default(data,start,formula,order, lag, slag,
-                                history, type, h, end, level, hpc, verbose, plot))
+        history, type, h, end, level, hpc, verbose, plot, sbins))
   }
 }
 
@@ -214,7 +216,7 @@ bfastmonitor <- function(data, start,
                          order = 3, lag = NULL, slag = NULL,
                          history = c("ROC", "BP", "all"),
                          type = "OLS-MOSUM", h = 0.25, end = 10, level = 0.05,
-                         hpc = "none", verbose = FALSE, plot = FALSE)
+                         hpc = "none", verbose = FALSE, plot = FALSE, sbins = 1)
 {
   ## PREPROCESSING
   ## two levels needed: 1. monitoring, 2. in ROC (if selected)
@@ -230,7 +232,7 @@ bfastmonitor <- function(data, start,
   
 
   ## full data
-  data_tspp <- bfastpp(data, order = order, lag = lag, slag = slag)
+  data_tspp <- bfastpp(data, order = order, lag = lag, slag = slag, sbins = sbins)
   data_tsmat = model.matrix(formula, data_tspp)
   X = data_tsmat
   y = data_tspp$response
@@ -369,7 +371,7 @@ bfastmonitor <- function(data, start,
                          order = 3, lag = NULL, slag = NULL,
                          history = c("ROC", "BP", "all"),
                          type = "OLS-MOSUM", h = 0.25, end = 10, level = 0.05,
-                         hpc = "none", verbose = FALSE, plot = FALSE)
+                         hpc = "none", verbose = FALSE, plot = FALSE, sbins = 1)
 {
   ## PREPROCESSING
   ## two levels needed: 1. monitoring, 2. in ROC (if selected)
@@ -384,7 +386,7 @@ bfastmonitor <- function(data, start,
   start <- time2num(start)
   
   ## full data
-  data_tspp <- bfastpp(data, order = order, lag = lag, slag = slag)
+  data_tspp <- bfastpp(data, order = order, lag = lag, slag = slag, sbins = sbins)
   
   ## SELECT STABLE HISTORY  
   ## full history period

--- a/R/bfastpp.R
+++ b/R/bfastpp.R
@@ -34,6 +34,10 @@
 #' @param decomp "stlplus" or "stl": use the NA-tolerant decomposition package
 #' or the reference package (which can make use of time series with 2-3
 #' observations per year)
+#' @param sbins numeric. Controls the number of seasonal dummies. If integer
+#' > 1, sets the number of seasonal dummies to use per year.
+#' If <= 1, treated as a multiplier to the number of observations per year, i.e.
+#' ndummies = nobs/year * sbins.
 #' @return If no formula is provided, \code{bfastpp} returns a
 #' \code{"data.frame"} with the following variables (some of which may be
 #' matrices).  \item{time}{numeric vector of time stamps,}
@@ -87,7 +91,7 @@
 bfastpp<- function(data, order = 3,
                    lag = NULL, slag = NULL, na.action = na.omit,
                    stl = c("none", "trend", "seasonal", "both"),
-                   decomp=c("stlplus", "stl"))
+                   decomp=c("stlplus", "stl"), sbins=1)
 {
   decomp = match.arg(decomp)
   if(decomp == "stlplus" && !require("stlplus",quietly = T)) stop("Please install the stlplus package or set decomp=stl.")
@@ -132,7 +136,7 @@ bfastpp<- function(data, order = 3,
     time = as.numeric(time(y)),
     response = y,
     trend = 1:NROW(y),
-    season = factor(cycle(y))
+    season = cut(cycle(y), if (sbins > 1) sbins else frequency(y)*sbins, ordered_result = TRUE)
   )
   
   ## set up harmonic trend matrix as well


### PR DESCRIPTION
Implemented for bfastpp, bfastmonitor and bfast01.
Depends on #50. Closes #47.