### PR TITLE
Fix set fast options #73

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -38,7 +38,6 @@
 #' 
 #' @export set_fast_options set_default_options
 set_fast_options <- function() {
-  
   if (!requireNamespace("strucchangeRcpp", quietly = TRUE)) {
     warning("package strucchangeRcpp required for enabling fast options; using default implementation of strucchange")
   }
@@ -47,13 +46,13 @@ set_fast_options <- function() {
                    bfast.prefer_matrix_methods=TRUE,
                    bfast.use_bfastts_modifications=TRUE))
   }
- 
 }
 
 
-
 set_default_options <- function() {
-  return(options(strucchange.use_armadillo=FALSE, 
-                 bfast.prefer_matrix_methods=FALSE,
-                 bfast.use_bfastts_modifications=FALSE))
+  if (requireNamespace("strucchangeRcpp", quietly = TRUE)) {
+    return(options(strucchange.use_armadillo=FALSE, 
+                   bfast.prefer_matrix_methods=FALSE,
+                   bfast.use_bfastts_modifications=FALSE))
+  }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -38,18 +38,16 @@
 #' 
 #' @export set_fast_options set_default_options
 set_fast_options <- function() {
-  env.strucchange = as.environment("package:strucchange")
   
-  # check existence of required strucchange functions
-  flist = c("monitor.matrix","efp.matrix","mefp.matrix",
-            "breakpoints.matrix", "root.matrix.crossprod")
-  if (!all(sapply(flist, function(x) exists(x, envir = env.strucchange))))
-  {
-    stop("failed to set fast options, please reinstall strucchange from http://github.com/appelmar/strucchange")
+  if (!requireNamespace("strucchangeRcpp", quietly = TRUE)) {
+    warning("package strucchangeRcpp required for enabling fast options; using default implementation of strucchange")
   }
-  return(options(strucchange.use_armadillo=TRUE, 
-                 bfast.prefer_matrix_methods=TRUE,
-                 bfast.use_bfastts_modifications=TRUE))
+  else {
+    return(options(strucchange.use_armadillo=TRUE, 
+                   bfast.prefer_matrix_methods=TRUE,
+                   bfast.use_bfastts_modifications=TRUE))
+  }
+ 
 }
 
 


### PR DESCRIPTION
This should fix R CMD check issues (see #73) with `set_fast_options()`. A warning is given when users call the function but do not have `strucchangeRcpp` installed. This check should not be necessary when we define  `strucchangeRcpp` as an imported package.