### PR TITLE
Add support for running an sctest in bfastlite()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bfast
-Version: 1.6.1
+Version: 1.7.0
 Title: Breaks for Additive Season and Trend
 Authors@R: c(person(given = "Jan", family = "Verbesselt", role = c("aut"), email = "Jan.Verbesselt@wur.nl"),
              person(given = "Dainius", family = "Masiliunas", role = c("aut", "cre"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+Changes in Version 1.7.0
+
+  o Added the option to run a structural change test before running bfastlite()
+  with two parameters: 'level' and 'type', equivalent to bfast() except that
+  anything equal to or below 0 in 'level' will skip the sctest.
+
 Changes in Version 1.6.1
 
   o Fixed a heap overflow issue in the C++ version of bfastts().

--- a/R/bfastlite.R
+++ b/R/bfastlite.R
@@ -54,7 +54,8 @@ bfastlite <- function(data, formula = response ~ trend + harmon,
 
   # If requested by the user, run an sctest before running anything else
   if (level > 0) {
-    sct <- sctest(efp(formula = formula, h = h, type = type, data = data_pp))
+    sct <- strucchangeRcpp::sctest(strucchangeRcpp::efp(
+      formula = formula, h = h, type = type, data = data_pp))
     if (!is.null(sct$p.value) && sct$p.value > level)
       return(structure(list(breakpoints = NA,
         data_pp = data_pp, sctest = sct), class = "bfastlite"))

--- a/R/bfastlite.R
+++ b/R/bfastlite.R
@@ -20,14 +20,22 @@
 #' to do light-weight detection of multiple breaks in a time series
 #' while also being able to deal with NA values by excluding them
 #' via \code{bfastpp}.
-#'
+#' 
+#' @param level numeric; threshold value for the \link[strucchangeRcpp]{sctest.efp}
+#' test for at least one break in a time series, to save processing time for
+#' no-change areas. The test is skipped if set to <= 0.
+#' @param type character, indicating the type argument to
+#' \link[strucchangeRcpp]{efp}.
 #' @param ... Additional arguments to \code{\link[strucchangeRcpp]{breakpoints}}.
 #' @inheritParams bfastpp
 #' @inheritParams strucchangeRcpp::breakpoints
-#' @return An object of class \code{bfastlite}, with two elements:
+#' @return An object of class \code{bfastlite}, with three elements:
 #' \item{breakpoints}{output from \code{\link[strucchangeRcpp]{breakpoints}},
 #' containing information about the estimated breakpoints.}
 #' \item{data_pp}{preprocessed data as output by \code{\link{bfastpp}}.}
+#' \item{sctest}{output from \code{\link[strucchangeRcpp]{sctest.efp}},
+#' contatining information about the likelihood of the time series
+#' having at least one break.}
 #' @author Dainius Masiliunas, Jan Verbesselt
 #' @example examples/bfastlite.r
 #'
@@ -37,15 +45,25 @@ bfastlite <- function(data, formula = response ~ trend + harmon,
                    order = 3, breaks = "LWZ",
                    lag = NULL, slag = NULL, na.action = na.omit,
                    stl = c("none", "trend", "seasonal", "both"),
-                   decomp = c("stl", "stlplus"), sbins = 1, ...)
+                   decomp = c("stl", "stlplus"), sbins = 1,
+                   h = 0.15, level = 0, type = "OLS-MOSUM", ...)
 {
   data_pp <- bfastpp(data, order = order,
                    lag = lag, slag = slag, na.action = na.action,
                    stl = stl, decomp = decomp, sbins = sbins)
+
+  # If requested by the user, run an sctest before running anything else
+  if (level > 0) {
+    sct <- sctest(efp(formula = formula, h = h, type = type, data = data_pp))
+    if (!is.null(sct$p.value) && sct$p.value > level)
+      return(structure(list(breakpoints = NA,
+        data_pp = data_pp, sctest = sct), class = "bfastlite"))
+  } else sct <- NA
+
   breakpoints <- strucchangeRcpp::breakpoints(
-    formula = formula, data = data_pp, breaks = breaks, ...)
+    formula = formula, data = data_pp, breaks = breaks, h = h, ...)
   Result <- structure(list(breakpoints = breakpoints,
-    data_pp = data_pp), class = "bfastlite")
+    data_pp = data_pp, sctest = sct), class = "bfastlite")
   return(Result)
 }
 
@@ -72,22 +90,25 @@ plot.bfastlite = function(x, breaks = NULL, magstat = NULL, magcomp = "trend", .
 {
     # Plot the original time series
     plot(response ~ time, data = x$data_pp, type = "l", ...)
-    # Plot the fitted model in green
-    lines(fitted(x$breakpoints, breaks = breaks) ~ x$data_pp$time, col = "green")
     
-    # Get the requested breaks
-    bpOptim <- breakpoints(x$breakpoints, breaks = breaks)
-    
-    if (length(bpOptim$breakpoints) > 0 && !all(is.na(bpOptim$breakpoints))) {
-        bpTimes <- x$data_pp[bpOptim$breakpoints, "time"]
-        abline(v = bpTimes, col = "blue") # Detected breakpoints in blue
+    if (!identical(x$breakpoints, NA)) {
+        # Plot the fitted model in green
+        lines(fitted(x$breakpoints, breaks = breaks) ~ x$data_pp$time, col = "green")
         
-        # If magnitudes requested, plot whiskers denoting magnitude
-        if (!is.null(magstat)) {
-            Mag <- strucchangeRcpp::magnitude(x$breakpoints, breaks = breaks, component = magcomp)$Mag
-            bpMag <- Mag[, colnames(Mag) %in% magstat]
-            bpY <- x$data_pp[bpOptim$breakpoints, "response"]
-            arrows(bpTimes, bpY-bpMag, bpTimes, bpY+bpMag, length = 0.05, angle = 90, code = 3, col = "blue")
+        # Get the requested breaks
+        bpOptim <- breakpoints(x$breakpoints, breaks = breaks)
+        
+        if (length(bpOptim$breakpoints) > 0 && !all(is.na(bpOptim$breakpoints))) {
+            bpTimes <- x$data_pp[bpOptim$breakpoints, "time"]
+            abline(v = bpTimes, col = "blue") # Detected breakpoints in blue
+            
+            # If magnitudes requested, plot whiskers denoting magnitude
+            if (!is.null(magstat)) {
+                Mag <- strucchangeRcpp::magnitude(x$breakpoints, breaks = breaks, component = magcomp)$Mag
+                bpMag <- Mag[, colnames(Mag) %in% magstat]
+                bpY <- x$data_pp[bpOptim$breakpoints, "response"]
+                arrows(bpTimes, bpY-bpMag, bpTimes, bpY+bpMag, length = 0.05, angle = 90, code = 3, col = "blue")
+            }
         }
     }
 }
@@ -96,5 +117,9 @@ plot.bfastlite = function(x, breaks = NULL, magstat = NULL, magcomp = "trend", .
 #' @export
 print.bfastlite <- function(x, ...)
 {
-    print(x$breakpoints)
+    if (identical(x$breakpoints, NA)) {
+        cat("The structural change test found no breakpoints for this time series,\ntherefore processing was skipped.\n")
+    } else {
+        print(x$breakpoints)
+    }
 }

--- a/examples/bfastlite.r
+++ b/examples/bfastlite.r
@@ -20,7 +20,9 @@ strucchangeRcpp::breakpoints(bp[["breakpoints"]], breaks = 2)
 plot(bp, magstat = "RMSD", magcomp = "harmoncos1", breaks = 2)
 
 # Try with a structural change test
-bfastlite(datats, level=0.05)
+bp <- bfastlite(datats, level=0.05)
+print(bp)
+plot(bp)
 
 # Details of the structural change test with the type RE
 bfastlite(datats, level=0.05, type="RE")$sctest

--- a/examples/bfastlite.r
+++ b/examples/bfastlite.r
@@ -18,3 +18,9 @@ strucchangeRcpp::breakpoints(bp[["breakpoints"]], breaks = 2)
 
 # Plot including magnitude based on RMSD for the cos1 component of harmonics
 plot(bp, magstat = "RMSD", magcomp = "harmoncos1", breaks = 2)
+
+# Try with a structural change test
+bfastlite(datats, level=0.05)
+
+# Details of the structural change test with the type RE
+bfastlite(datats, level=0.05, type="RE")$sctest

--- a/man/bfastlite.Rd
+++ b/man/bfastlite.Rd
@@ -16,6 +16,9 @@ bfastlite(
   stl = c("none", "trend", "seasonal", "both"),
   decomp = c("stl", "stlplus"),
   sbins = 1,
+  h = 0.15,
+  level = 0,
+  type = "OLS-MOSUM",
   ...
 )
 
@@ -30,6 +33,9 @@ bfast0n(
   stl = c("none", "trend", "seasonal", "both"),
   decomp = c("stl", "stlplus"),
   sbins = 1,
+  h = 0.15,
+  level = 0,
+  type = "OLS-MOSUM",
   ...
 )
 }
@@ -45,7 +51,7 @@ greater than 1 is required.}
 
 \item{breaks}{either a positive integer specifying the maximal number of breaks to be calculated,
     or a string specifying the information criterion to use to automatically determine
-    the optimal number of breaks (see also \code{\link{logLik}}.
+    the optimal number of breaks (see also \code{\link{logLik}}).
     \code{"all"} means the maximal number allowed by \code{h} is used.
     \code{NULL} is treated as the default of the \code{breakpoints} function (i.e. BIC).}
 
@@ -72,13 +78,27 @@ sets the number of seasonal dummies to use per year.
 If <= 1, treated as a multiplier to the number of observations per year, i.e.
 \code{ndummies = nobs/year * sbins}.}
 
+\item{h}{minimal segment size either given as fraction relative to the
+    sample size or as an integer giving the minimal number of observations
+    in each segment.}
+
+\item{level}{numeric; threshold value for the \link[strucchangeRcpp]{sctest.efp}
+test for at least one break in a time series, to save processing time for
+no-change areas. The test is skipped if set to <= 0.}
+
+\item{type}{character, indicating the type argument to
+\link[strucchangeRcpp]{efp}.}
+
 \item{...}{Additional arguments to \code{\link[strucchangeRcpp]{breakpoints}}.}
 }
 \value{
-An object of class \code{bfastlite}, with two elements:
+An object of class \code{bfastlite}, with three elements:
 \item{breakpoints}{output from \code{\link[strucchangeRcpp]{breakpoints}},
 containing information about the estimated breakpoints.}
 \item{data_pp}{preprocessed data as output by \code{\link{bfastpp}}.}
+\item{sctest}{output from \code{\link[strucchangeRcpp]{sctest.efp}},
+contatining information about the likelihood of the time series
+having at least one break.}
 }
 \description{
 A combination of \code{\link{bfastpp}} and \code{\link[strucchangeRcpp]{breakpoints}}
@@ -107,6 +127,12 @@ strucchangeRcpp::breakpoints(bp[["breakpoints"]], breaks = 2)
 
 # Plot including magnitude based on RMSD for the cos1 component of harmonics
 plot(bp, magstat = "RMSD", magcomp = "harmoncos1", breaks = 2)
+
+# Try with a structural change test
+bfastlite(datats, level=0.05)
+
+# Details of the structural change test with the type RE
+bfastlite(datats, level=0.05, type="RE")$sctest
 }
 \author{
 Dainius Masiliunas, Jan Verbesselt

--- a/tests/Examples/bfast-Ex.Rout.save
+++ b/tests/Examples/bfast-Ex.Rout.save
@@ -1,6 +1,6 @@
 
-R version 3.5.0 (2018-04-23) -- "Joy in Playing"
-Copyright (C) 2018 The R Foundation for Statistical Computing
+R version 4.1.0 (2021-05-18) -- "Camp Pontanezen"
+Copyright (C) 2021 The R Foundation for Statistical Computing
 Platform: x86_64-suse-linux-gnu (64-bit)
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
@@ -342,6 +342,20 @@ Corresponding to breakdates:
 > 
 > # Plot including magnitude based on RMSD for the cos1 component of harmonics
 > plot(bp, magstat = "RMSD", magcomp = "harmoncos1", breaks = 2)
+> 
+> # Try with a structural change test
+> bfastlite(datats, level=0.05)
+The structural change test found no breakpoints for this time series,
+therefore processing was skipped.
+> 
+> # Details of the structural change test with the type RE
+> bfastlite(datats, level=0.05, type="RE")$sctest
+
+	RE test (recursive estimates test)
+
+data:  efp(formula = formula, h = h, type = type, data = data_pp)
+RE = 6.3887, p-value < 2.2e-16
+
 > 
 > 
 > 
@@ -1007,7 +1021,7 @@ bibtex=TRUE)', 'toBibtex(.)', or set
 > cleanEx()
 > options(digits = 7L)
 > base::cat("Time elapsed: ", proc.time() - base::get("ptime", pos = 'CheckExEnv'),"\n")
-Time elapsed:  6.419 0.14 7.155 0.003 0 
+Time elapsed:  3.606 0.084 3.73 0.016 0.025 
 > grDevices::dev.off()
 null device 
           1 

--- a/tests/Examples/bfast-Ex.Rout.save
+++ b/tests/Examples/bfast-Ex.Rout.save
@@ -353,7 +353,7 @@ therefore processing was skipped.
 
 	RE test (recursive estimates test)
 
-data:  efp(formula = formula, h = h, type = type, data = data_pp)
+data:  strucchangeRcpp::efp(formula = formula, h = h, type = type, data = data_pp)
 RE = 6.3887, p-value < 2.2e-16
 
 > 
@@ -1021,7 +1021,7 @@ bibtex=TRUE)', 'toBibtex(.)', or set
 > cleanEx()
 > options(digits = 7L)
 > base::cat("Time elapsed: ", proc.time() - base::get("ptime", pos = 'CheckExEnv'),"\n")
-Time elapsed:  3.606 0.084 3.73 0.016 0.025 
+Time elapsed:  3.604 0.1 3.736 0.018 0.013 
 > grDevices::dev.off()
 null device 
           1 


### PR DESCRIPTION
New feature: running any sctest in `bfastlite()`. Pass a value to `level` to activate it (by default off). Can choose from any EFP type, though OLS-MOSUM does not seem particularly effective, even though it's default in `bfast()`?

Closes #61.